### PR TITLE
fix symlink in parent path

### DIFF
--- a/wizwad/wad.py
+++ b/wizwad/wad.py
@@ -192,9 +192,11 @@ class Wad:
                 for file in self._file_map.values():
                     file_path = (path / file.name).resolve()
 
+                    # we need to resolve both since `path` may have symlinks in it
+                    # and the previous .resolve would have resolved these
                     if not file_path.is_relative_to(path.resolve()):
                         raise RuntimeError(
-                            f"Escaping path detected: {file.name} {file_path=} {path=}"
+                            f"Escaping path detected: {file.name} -> {file_path}"
                         )
 
                     file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/wizwad/wad.py
+++ b/wizwad/wad.py
@@ -193,7 +193,9 @@ class Wad:
                     file_path = (path / file.name).resolve()
 
                     if not file_path.is_relative_to(path):
-                        raise RuntimeError(f"Escaping path detected: {file.name}")
+                        raise RuntimeError(
+                            f"Escaping path detected: {file.name} {file_path=} {path=}"
+                        )
 
                     file_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/wizwad/wad.py
+++ b/wizwad/wad.py
@@ -192,7 +192,7 @@ class Wad:
                 for file in self._file_map.values():
                     file_path = (path / file.name).resolve()
 
-                    if not file_path.is_relative_to(path):
+                    if not file_path.is_relative_to(path.resolve()):
                         raise RuntimeError(
                             f"Escaping path detected: {file.name} {file_path=} {path=}"
                         )


### PR DESCRIPTION
this fixes the case of a parent having a symlink in it causing the parent check to fail due to the sub path having these links resolved but the parent not